### PR TITLE
For the `/node` config, disable all `eslint-plugin-n` rules related to `import` and `require` that have too many false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.1
+
+- For the `/node` config, disable all `eslint-plugin-n` rules related to `import` and `require` that have too many false positives:
+  - `n/no-extraneous-import`
+  - `n/no-extraneous-require`
+  - `n/no-missing-import`
+  - `n/no-missing-require`
+  - `n/no-unpublished-import`
+  - `n/no-unpublished-require`
+
 ## 1.0.0
 
 - First public release

--- a/lib/eslintNodeConfig.json
+++ b/lib/eslintNodeConfig.json
@@ -6,7 +6,13 @@
     "node": true
   },
   "rules": {
+    "n/no-extraneous-import": "off",
+    "n/no-extraneous-require": "off",
+    "n/no-missing-import": "off",
+    "n/no-missing-require": "off",
     "n/no-path-concat": "error",
+    "n/no-unpublished-import": "off",
+    "n/no-unpublished-require": "off",
     "n/prefer-global/console": "error",
     "n/prefer-global/text-decoder": "error",
     "n/prefer-global/text-encoder": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babbel/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babbel/eslint-config",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "6.7.0",
         "@typescript-eslint/parser": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical ESLint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) and [`package-lock.json`](/package-lock.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.0.1`
- For the `/node` config, disable all `eslint-plugin-n` rules related to `import` and `require` that have too many false positives:
  - `n/no-extraneous-import`
  - `n/no-extraneous-require`
  - `n/no-missing-import`
  - `n/no-missing-require`
  - `n/no-unpublished-import`
  - `n/no-unpublished-require`