### PR TITLE
Consistent type import sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+- Sort type imports first by builtin and external types group and then into an internal types group. Otherwise [perfectionist sorts the types alphabetically](https://github.com/azat-io/eslint-plugin-perfectionist/issues/295). Sorting the types in this way is consistent with the non type imports and the previous `import/order` rules.
+
 ## 2.1.1
 
 - Improve TypeScript type-aware linting compatibility by passing `true` to `project` instead of a relative path. This should [auto-find the `tsconfig.json` file nearest the source file being linted](https://typescript-eslint.io/packages/parser/#project).

--- a/lib/eslintBaseConfig.json
+++ b/lib/eslintBaseConfig.json
@@ -49,15 +49,8 @@
           ["builtin", "external"],
           ["index", "internal", "parent", "sibling", "unknown"],
           "object",
-          [
-            "builtin-type",
-            "external-type",
-            "index-type",
-            "internal-type",
-            "parent-type",
-            "sibling-type",
-            "type"
-          ],
+          ["builtin-type", "external-type"],
+          ["index-type", "internal-type", "parent-type", "sibling-type", "type"],
           "style"
         ]
       }

--- a/lib/eslintBunConfig.json
+++ b/lib/eslintBunConfig.json
@@ -16,15 +16,8 @@
           ["builtin", "external"],
           ["index", "internal", "parent", "sibling", "unknown"],
           "object",
-          [
-            "builtin-type",
-            "external-type",
-            "index-type",
-            "internal-type",
-            "parent-type",
-            "sibling-type",
-            "type"
-          ],
+          ["builtin-type", "external-type"],
+          ["index-type", "internal-type", "parent-type", "sibling-type", "type"],
           "style"
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/eslint-config",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical ESLint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [X] Readme and changelog updates were made reflecting this PR's changes
- [X] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)

**Changes Included**

Sort type import into two groups, an external and built-in type group and an internal type group. this is to be consistent with the previous `import/order` rule and how non-type imports are sorted.

At the moment the types are sorted alphabetically. This is "by design' behavior in perfectionist and not a bug, see [discussion in this bug report](https://github.com/azat-io/eslint-plugin-perfectionist/issues/295).

> string[] — An import matching any of the values of the array will be marked as part of the group referenced by the key. The order of values in the array does not matter. 
> https://perfectionist.dev/rules/sort-imports

example before this rule change:
```typescript
import type {
  customErrorCodes,
} from './schema';
import type { z } from 'zod';
```

After this rule change
```typescript
import type { z } from 'zod';

import type {
  customErrorCodes
} from './schema';
```