### PR TITLE
Dev/pnapl 765/new way of loading GitHub secrets

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           parse-json-secrets: true
-          secret-ids: ",${{ vars.NPM_USER_SECRET_ARN }}"
+          secret-ids: NPM_USER,${{ vars.NPM_USER_SECRET_ARN }}
       - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: CPU Details
         run: lscpu
@@ -13,6 +16,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.1.27"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          parse-json-secrets: true
+          secret-ids: ",${{ vars.NPM_USER_SECRET_ARN }}"
       - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,4 +32,4 @@ jobs:
         with:
           access: public
           registry: https://registry.npmjs.org/
-          token: ${{ secrets.NPM_USER_ACCESS_TOKEN }}
+          token: ${{ env.NPM_USER_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Updated publish workflow's way of retrieving secrets
+
 ## 2.2.0
 
 - Add `eslint-plugin-react-compiler` to all React- and Preact-based configs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/eslint-config",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical ESLint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [X] Readme and changelog updates were made reflecting this PR's changes
- [X] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)

**Changes Included**

Follow-up from the previous PR #30 , looks like the variables created [here](https://github.com/babbel/eslint-config/actions/runs/13675350757/job/38234521808#step:7:16) don't have the exact right names (they should be `NPM_USER_EMAIL` and `NPM_USER_ACCESS_TOKEN`, fixing that with this PR

